### PR TITLE
Fix a bug that log parsing failed

### DIFF
--- a/gitlogs/main.go
+++ b/gitlogs/main.go
@@ -39,7 +39,12 @@ func NewCheckoutLog(message string) CheckoutLog {
 }
 
 func NewLog(logString string) Log {
-	parsedLog := logRegex.FindAllStringSubmatch(logString, -1)[0]
+	parsedLogString := logRegex.FindAllStringSubmatch(logString, -1)
+	if parsedLogString == nil {
+		return Log{}
+	}
+
+	parsedLog := parsedLogString[0]
 	unix, err := strconv.ParseInt(parsedLog[5], 10, 64)
 
 	if err != nil {


### PR DESCRIPTION
There is a pattern that fails parsing the HEAD log.

```
d55238945dd336b02288bd31297112********** 4ac5298b94602d4e33f6995b585094********** tomotaka-yamasaki <tomotaka.yamasaki@aktsk.jp> 1482795210 +0900  pull origin fuga: hoge
4ac5298b94602d4e33f6995b5850945********* 563fc2c4a52e45cacf7d1a86117f8b5********* tomotaka-yamasaki <tomotaka.yamasaki@aktsk.jp> 1482799950 +0900  pull origin hoge: hogehoge
563fc2c4a52e45cacf7d1a86117f8b5********* 563fc2c4a52e45cacf7d1a86117f8b********** tomotaka-yamasaki <tomotaka.yamasaki@aktsk.jp> 1482799960 +0900  checkout: moving from hoge to hogehoge
563fc2c4a52e45cacf7d1a86117f8*********** 0000000000000000000000000000000000000000 tomotaka-yamasaki <tomotaka.yamasaki@aktsk.jp> 1482799998 +0900
563fc2c4a52e45cacf7d1a86117f8b********** ffe900d5d215e09f4c284cdf91144*********** tomotaka-yamasaki <tomotaka.yamasaki@aktsk.jp> 1482807269 +0900  commit: hogehoge
```

- I failed parsing because there is no command log.

## change
- Add nil check of parsing.
